### PR TITLE
Add reading an instance host/baseUrl from environment

### DIFF
--- a/src/main/scala/com/codacy/api/CodacyAPIClient.scala
+++ b/src/main/scala/com/codacy/api/CodacyAPIClient.scala
@@ -15,7 +15,7 @@ class CodacyAPIClient {
 
   def postCoverageFile(projectToken: String, commitUuid: String, file: File): Either[String, String] = {
     //quick-fix load codacy instance from environment instead of only hardcoded.
-    val host = sys.env.get("CODACY_INSTANCE_URL").getOrElse("https://www.codacy.com/")
+    val host = sys.env.get("CODACY_INSTANCE_URL").getOrElse("https://www.codacy.com")
     val url = s"$host/api/coverage/$projectToken/$commitUuid"
 
     val responseOpt = Try {

--- a/src/main/scala/com/codacy/api/CodacyAPIClient.scala
+++ b/src/main/scala/com/codacy/api/CodacyAPIClient.scala
@@ -14,7 +14,9 @@ class CodacyAPIClient {
   val client: WSClient = new NingWSClient(new AsyncHttpClient().getConfig)
 
   def postCoverageFile(projectToken: String, commitUuid: String, file: File): Either[String, String] = {
-    val url = s"https://www.codacy.com/api/coverage/$projectToken/$commitUuid"
+    //quick-fix load codacy instance from environment instead of only hardcoded.
+    val host = sys.env.get("CODACY_INSTANCE_URL").getOrElse("https://www.codacy.com/")
+    val url = s"$host/api/coverage/$projectToken/$commitUuid"
 
     val responseOpt = Try {
       val future = client.url(url).post(file)


### PR DESCRIPTION
Currently the plugin as-is can only transmit to the open-source codacy instance.  This is a fairly quick change to check an environment variable first to allow the ability to point to a private instance.  There are far better ways to do this (config files, sbt variables/keys and other such things), but this is a quick-and-dirty way to get past the pure hard-code for now.
