### PR TITLE
Adding ability to specify custom codacy API base

### DIFF
--- a/src/main/scala/com/codacy/api/CodacyAPIClient.scala
+++ b/src/main/scala/com/codacy/api/CodacyAPIClient.scala
@@ -13,8 +13,8 @@ import scala.util.Try
 class CodacyAPIClient {
   val client: WSClient = new NingWSClient(new AsyncHttpClient().getConfig)
 
-  def postCoverageFile(projectToken: String, commitUuid: String, file: File): Either[String, String] = {
-    val url = s"https://www.codacy.com/api/coverage/$projectToken/$commitUuid"
+  def postCoverageFile(projectToken: String, commitUuid: String, file: File, baseUrl: String): Either[String, String] = {
+    val url = s"$baseUrl/api/coverage/$projectToken/$commitUuid"
 
     val responseOpt = Try {
       val future = client.url(url).post(file)


### PR DESCRIPTION
This patch will allow users of an on-site install to integrate coverage results by overriding the base of the API URL the plugin uses to post results to. Please raise issues or concerns about the implementation.

The value can be changed within the build settings or by an environment variable, `CODACY_API_BASE_URL`, with the environment variable taking precedence. If neither is found, the value defaults to the public host.
