### PR TITLE
Bump the coverageparser to 1.1.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   lazy val codacyScalaApi = "com.codacy" %% "codacy-api-scala" % "1.0.2"
-  lazy val coverageParser = "com.codacy" %% "coverage-parser" % "1.1.1"
+  lazy val coverageParser = "com.codacy" %% "coverage-parser" % "1.1.3"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 
 }


### PR DESCRIPTION
This library version has added support for locale dependent separator in coverage file.
